### PR TITLE
feat(cli): add prune command for manifest noise cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.1.0-rc.7 - 2026-02-22
+- Added new `prune` command for manifest-only cleanup of stale font entries.
+- `prune` defaults to dry-run and supports `--apply`, `--rule`, and `--max-removals`.
+- Default prune rule removes fonts only when both conditions are true: no discovered font file and no usage matches.
+- Applying prune now removes orphaned linked license instances that are no longer referenced by remaining fonts.
+- Added new event types: `manifest.font_pruned`, `manifest.license_instance_pruned`, and `prune.completed`.
+- Added CLI integration tests for prune dry-run and apply flows.
+- Updated README and specs to document prune workflow.
+
 ## 0.1.0-rc.6 - 2026-02-21
 - Focused `scan --discover` on font-relevant results by restricting discovered license files to font-adjacent paths.
 - Added default ignore rules for dependency directories (`vendor`, `bower_components`) in scanner traversal.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install -g @setzkasten/cli
 setzkasten init --name "My Project"
 setzkasten add --font-id inter --family "Inter" --source oss
 setzkasten scan --path . --discover
+setzkasten prune --path . --apply
 setzkasten evidence add --license-id lic_inter_001 --file ./licenses/OFL.txt
 setzkasten policy
 setzkasten quote
@@ -31,6 +32,7 @@ npm run build
 node packages/cli/src/index.js init
 node packages/cli/src/index.js add --font-id inter --family "Inter" --source oss
 node packages/cli/src/index.js scan --discover
+node packages/cli/src/index.js prune --apply
 node packages/cli/src/index.js evidence add --license-id lic_inter_001 --file ./licenses/OFL.txt
 node packages/cli/src/index.js policy
 node packages/cli/src/index.js quote
@@ -41,6 +43,7 @@ node packages/cli/src/index.js quote
 - `add`
 - `remove`
 - `scan`
+- `prune`
 - `evidence add`
 - `policy`
 - `quote`
@@ -49,6 +52,7 @@ node packages/cli/src/index.js quote
 ## License Workflow
 - `scan --discover` finds font files and font-adjacent license files in the repository.
 - Root scans ignore dependency directories like `node_modules` and `vendor` by default.
+- `prune` removes manifest-only noise (dry-run by default) and can remove orphaned linked license instances when applying.
 - Discovered license files include a deterministic `document_hash` (sha256) in CLI output.
 - `evidence add` links a local license document hash to a `license_instance`.
 - `policy` warns when BYO fonts have no linked license instance or no evidence.

--- a/docs/specs/event-log.md
+++ b/docs/specs/event-log.md
@@ -23,8 +23,11 @@ Required fields:
 - `manifest.created`
 - `manifest.font_added`
 - `manifest.font_removed`
+- `manifest.font_pruned`
+- `manifest.license_instance_pruned`
 - `manifest.license_ref_added` (evidence hash linked or updated for a license instance)
 - `scan.completed`
+- `prune.completed`
 - `policy.ok`
 - `policy.warning_raised`
 - `quote.generated`

--- a/docs/specs/v1-feature-set.md
+++ b/docs/specs/v1-feature-set.md
@@ -19,6 +19,10 @@ Goal: developer workflow for lawful, auditable font usage in projects.
   - dependency directories (`node_modules`, `vendor`) ignored by default
   - deterministic file fingerprint (`document_hash`) for discovered license files
   - domain scan only after domain verification (interface prepared)
+- `setzkasten prune`
+  - manifest-only cleanup (dry-run by default)
+  - default rule: remove fonts with no discovered file and no usage match
+  - removes orphaned linked license instances when applying
 - `setzkasten evidence add`
   - attach/update evidence for an existing `license_instance` from a local file
   - store hash + metadata in manifest (not file contents)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,6 +7,7 @@ CLI-first tool for font license governance, audit logging, and deterministic pol
 - Writes an append-only event log (`.setzkasten/events.log`)
 - Adds/removes font entries
 - Scans controlled local assets for usage signals
+- Prunes manifest noise (`prune`) based on discovered files + usage signals
 - Discovers likely license files and computes deterministic `document_hash` values
 - Links license evidence files to existing license instances (`evidence add`)
 - Evaluates policy decisions (`allow`, `warn`, `escalate`)
@@ -23,6 +24,7 @@ npm install -g @setzkasten/cli
 setzkasten init --name "My Project"
 setzkasten add --font-id inter --family "Inter" --source oss
 setzkasten scan --path . --discover
+setzkasten prune --path . --apply
 setzkasten evidence add --license-id lic_inter_001 --file ./licenses/OFL.txt
 setzkasten policy
 setzkasten quote
@@ -39,6 +41,21 @@ setzkasten evidence add --license-id <license_id> --file <path-to-license-file>
 4. Run `setzkasten policy` to verify BYO evidence state.
 
 Dependency directories such as `node_modules` and `vendor` are ignored during scans by default.
+
+## Prune Workflow (Manifest-only)
+1. Run a dry-run:
+```bash
+setzkasten prune --path .
+```
+2. Review candidates (`missing_font_file`, `no_usage_refs`).
+3. Apply cleanup:
+```bash
+setzkasten prune --path . --apply
+```
+4. Optional stricter rule:
+```bash
+setzkasten prune --path . --rule no-file --apply
+```
 
 ## Data written locally
 - `LICENSE_MANIFEST.json`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setzkasten/cli",
-  "version": "0.1.0-rc.6",
+  "version": "0.1.0-rc.7",
   "description": "Setzkasten CLI for font license governance and audit trails.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Add new CLI command 'setzkasten prune' with dry-run default and apply mode.

Prune evaluates manifest fonts against discovered font files and scan usage using rule no-file-and-no-usage (default) or no-file.

When applying, remove stale fonts from manifest and prune orphaned linked license instances; append prune audit events.

Document the new workflow and bump @setzkasten/cli to 0.1.0-rc.7.

## Scope
- What changed?

## Checklist
- [ ] Tests added/updated
- [ ] Docs/specs updated if contracts changed
- [ ] No proprietary font hosting/preview introduced
